### PR TITLE
hercules-ci-agent: binary caches support

### DIFF
--- a/modules/services/hercules-ci-agent/common.nix
+++ b/modules/services/hercules-ci-agent/common.nix
@@ -1,0 +1,119 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkOption mkIf types filterAttrs;
+  inherit (pkgs.callPackage ./to-toml {}) toTOML;
+
+  cfg =
+    config.services.hercules-ci-agent;
+in
+{
+  imports = [
+    ./gc.nix
+    ./system-caches.common.nix
+  ];
+
+  options.services.hercules-ci-agent = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "If true, run the agent as a system service";
+    };
+    baseDirectory = mkOption {
+      type = types.path;
+      default = "/var/lib/hercules-ci-agent";
+      description = "State directory (secrets, work directory, etc) for agent";
+    };
+    user = mkOption {
+      description = "Unix system user that runs the agent service";
+      type = types.string;
+    };
+    package = let
+        version = "0.3";
+      in mkOption {
+      description = "Package containing the bin/hercules-ci-agent program";
+      type = types.package;
+      default = (import (builtins.fetchTarball "https://github.com/hercules-ci/hercules-ci-agent/archive/v${version}.gz") {}).hercules-ci-agent;
+      defaultText = "hercules-ci-agent-${version}";
+    };
+    extraOptions = mkOption {
+      description = ''
+        This lets you can add extra options to the agent's config file, in case
+        you are using an upstreamed module with a newer version of the package.
+
+        These will override the other options in this module.
+
+        We recommend that you use the other options where possible, because
+        extraOptions can not provide a merge function for the contents of the
+        fields.
+        '';
+      type = types.attrsOf types.unspecified;
+      default = {};
+    };
+    binaryCachesFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        A file path to be read at evaluation time, to configure the system's
+        cache settings.
+
+        For the format, see https://docs.hercules-ci.com/#binaryCachesPath
+      '';
+    };
+
+    concurrentTasks = mkOption {
+      description = "Number of tasks to perform simultaneously, such as evaluations, derivations";
+      type = types.int;
+      default = 4;
+    };
+
+    /*
+      Internal and/or computed values
+     */
+    finalConfig = mkOption {
+      type = types.attrsOf types.unspecified;
+      readOnly = true;
+      internal = true;
+      description = ''
+        The fully assembled config file as an attribute set, right before it's
+        written to file.
+      '';
+    };
+    tomlFile = mkOption {
+      type = types.path;
+      readOnly = true;
+      internal = true;
+      description = ''
+        The fully assembled config file.
+      '';
+    };
+    secretsDirectory = mkOption {
+      type = types.path;
+      readOnly = true;
+      internal = true;
+      description = ''
+        Secrets directory derived from baseDirectory.
+      '';
+    };
+    # TODO: expose all file and directory locations as readOnly options
+  };
+
+  config = mkIf cfg.enable {
+    services.hercules-ci-agent = {
+      secretsDirectory = cfg.baseDirectory + "/secrets";
+      tomlFile = pkgs.writeText "hercules-ci-agent.toml"
+                                (toTOML cfg.finalConfig);
+
+      finalConfig = filterAttrs (k: v: k == "binaryCachesPath" -> v != null) (
+        {
+          inherit (cfg) concurrentTasks baseDirectory;
+        } // cfg.extraOptions
+      );
+
+      # TODO: expose only the (future) main directory as an option and derive
+      # all locations from finalConfig.
+      extraOptions.clusterJoinTokenPath = lib.mkDefault (cfg.secretsDirectory + "/cluster-join-token.key");
+      extraOptions.binaryCachesPath = lib.mkDefault (lib.mapNullable (_f: cfg.secretsDirectory + "/binary-caches.json") cfg.binaryCachesFile);
+    };
+  };
+}

--- a/modules/services/hercules-ci-agent/common.nix
+++ b/modules/services/hercules-ci-agent/common.nix
@@ -29,11 +29,11 @@ in
       type = types.string;
     };
     package = let
-        version = "0.3";
+        version = "0.3.0";
       in mkOption {
       description = "Package containing the bin/hercules-ci-agent program";
       type = types.package;
-      default = (import (builtins.fetchTarball "https://github.com/hercules-ci/hercules-ci-agent/archive/v${version}.gz") {}).hercules-ci-agent;
+      default = (import (builtins.fetchTarball "https://github.com/hercules-ci/hercules-ci-agent/archive/hercules-ci-agent-${version}.tar.gz") {}).hercules-ci-agent;
       defaultText = "hercules-ci-agent-${version}";
     };
     extraOptions = mkOption {

--- a/modules/services/hercules-ci-agent/default.nix
+++ b/modules/services/hercules-ci-agent/default.nix
@@ -5,62 +5,21 @@ with lib;
 let
   cfg = config.services.hercules-ci-agent;
   user = config.users.users.hercules-ci-agent;
+  binaryCachesPathDeployed = cfg.secretsDirectory + "/binary-caches.json";
 in {
+  imports = [ ./common.nix ];
+
   options.services.hercules-ci-agent = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Run Hercules CI Agent as a system service";
-    };
-
-    apiBaseUrl = mkOption {
-      description = "Alternative base URL for the Hercules API";
-      example = "https://hercules-ci.com";
-      default = null;
-      type = types.nullOr types.string;
-    };
-
-    clusterJoinTokenPath = mkOption {
-      description = ''
-        Location of a the cluster join token. It authorizes the agent to add
-        itself to the cluster that the token represents.
-
-        This file is only required to be present for the agent's first run. It
-        will be ignored after the agent has used the token successfully.
-      '';
-      type = types.path;
-    };
-
     logFile = mkOption {
       type = types.path;
       default = "/var/log/hercules-ci-agent.log";
       description = "Stdout and sterr of hercules-ci-agent process.";
     };
-
-    concurrentTasks = mkOption {
-      description = "Number of tasks to perform simultaneously, such as evaluations, derivations";
-      type = types.int;
-      default = 4;
-    };
-
-    package = mkOption {
-      type = types.package;
-      default = (import (builtins.fetchTarball "https://github.com/hercules-ci/hercules-ci-agent/archive/stable.tar.gz") {}).hercules-ci-agent;
-      defaultText = ''(import (builtins.fetchTarball "https://github.com/hercules-ci/hercules-ci-agent/archive/stable.tar.gz") {}).hercules-ci-agent'';
-      description = ''
-        Package containing the bin/hercules-ci-agent program.
-      '';
-    };
   };
 
   config = mkIf cfg.enable {
     launchd.daemons.hercules-ci-agent = {
-      script = ''
-        exec ${cfg.package}/bin/hercules-ci-agent \
-          ${if (cfg.apiBaseUrl == null) then "" else "--api-base-url ${escapeShellArg cfg.apiBaseUrl}"} \
-          --cluster-join-token-path ${escapeShellArg cfg.clusterJoinTokenPath} \
-          --concurrent-tasks ${toString cfg.concurrentTasks}
-      '';
+      script = "exec ${cfg.package}/bin/hercules-ci-agent --config ${cfg.tomlFile}";
 
       path = [ config.nix.package ];
       environment = {
@@ -75,24 +34,31 @@ in {
       serviceConfig.UserName = "hercules-ci-agent";
       serviceConfig.WorkingDirectory = user.home;
       serviceConfig.WatchPaths = [
-        cfg.clusterJoinTokenPath
+        cfg.secretsDirectory
       ];
     };
 
     system.activationScripts.preActivation.text = ''
       touch '${cfg.logFile}'
       chown ${toString user.uid}:${toString user.gid} '${cfg.logFile}'
+
+      echo "installing /etc/nix/daemon-netrc"
+      if [ -f ${escapeShellArg binaryCachesPathDeployed} ]; then
+        ${pkgs.jq}/bin/jq -r <${escapeShellArg binaryCachesPathDeployed} \
+            'to_entries[] | .key as $key | .value.authToken | select (. != null) | "machine \($key).cachix.org password \(.)" ' \
+            > /etc/nix/daemon-netrc
+        chmod 400 /etc/nix/daemon-netrc
+        chown root /etc/nix/daemon-netrc
+      fi
     '';
 
     users.knownGroups = [ "hercules-ci-agent" ];
     users.knownUsers = [ "hercules-ci-agent" ];
 
-    services.hercules-ci-agent.clusterJoinTokenPath = lib.mkDefault (user.home + "/agent-join-token.key");
-
     users.users.hercules-ci-agent = {
       uid = mkDefault 532;
       gid = mkDefault config.users.groups.hercules-ci-agent.gid;
-      home = mkDefault "/var/lib/hercules-ci-agent";
+      home = mkDefault cfg.baseDirectory;
       createHome = true;
       shell = "/bin/bash";
       description = "System user for the Hercules CI Agent";

--- a/modules/services/hercules-ci-agent/gc.nix
+++ b/modules/services/hercules-ci-agent/gc.nix
@@ -1,0 +1,23 @@
+{ lib, pkgs, config, ...}:
+let
+
+  inherit (lib) types mkIf mkOption;
+  cfg = config.services.hercules-ci-agent;
+
+in
+{
+  options.services.hercules-ci-agent = {
+    freespaceGB = mkOption {
+      type = types.nullOr types.int;
+      default = 30;
+      description = ''
+        Amount of free space (GB) to ensure on garbage collection
+      '';
+    };
+  };
+
+  config = mkIf (cfg.enable && cfg.freespaceGB != null) {
+    nix.gc.automatic = true;
+    nix.gc.options = ''--max-freed "$((${toString cfg.freespaceGB} * 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"'';
+  };
+}

--- a/modules/services/hercules-ci-agent/system-caches.common.nix
+++ b/modules/services/hercules-ci-agent/system-caches.common.nix
@@ -1,0 +1,47 @@
+# TODO (doc) CacheKeys format reference link
+/*
+  A module that configures an agent machine to use caches for reading and/or
+  writing.
+ */
+{ pkgs, lib, config, ...}:
+let
+  cfg = config.services.hercules-ci-agent;
+  inherit (cfg.finalConfig) binaryCachesPath;
+
+  inherit (lib.lists) filter concatMap concatLists;
+  inherit (lib) types isAttrs mkIf escapeShellArg attrValues mapAttrsToList filterAttrs;
+  inherit (builtins) readFile fromJSON map split;
+
+  allBinaryCaches =
+    if cfg.binaryCachesFile == null
+    then {}
+    else builtins.fromJSON (builtins.readFile cfg.binaryCachesFile);
+
+  cachixCaches =
+    filterAttrs (k: v: (v.kind or null) == "CachixCache") allBinaryCaches;
+
+  cachixVersionWarnings =
+    mapAttrsToList (k: v: "In file ${toString cfg.binaryCachesFile}, entry ${k}, unsupported CachixCache version ${(v.apiVersion or null)}")
+    (filterAttrs (k: v: (v.apiVersion or null) != null) cachixCaches);
+
+  otherCaches =
+    filterAttrs (k: v: (v.kind or null) != "CachixCache") allBinaryCaches;
+  otherCachesWarnings =
+    mapAttrsToList (k: v: "In file ${toString cfg.binaryCachesFile}, entry ${k}, unsupported cache with kind ${(v.kind or null)}") otherCaches;
+
+in
+{
+  config = mkIf (cfg.enable && cfg.binaryCachesFile != null) {
+
+    warnings = otherCachesWarnings ++ cachixVersionWarnings;
+
+    nix.trustedBinaryCaches = ["https://cache.nixos.org/"] ++ mapAttrsToList (name: keys: "https://${name}.cachix.org") cachixCaches;
+    nix.binaryCachePublicKeys = concatLists (mapAttrsToList (name: keys: keys.publicKeys) cachixCaches);
+
+    # This netrc file needs to be installed by system-caches.PLATFORM.nix
+    nix.extraOptions = ''
+      netrc-file = /etc/nix/daemon-netrc
+    '';
+
+  };
+}

--- a/modules/services/hercules-ci-agent/to-toml/default.nix
+++ b/modules/services/hercules-ci-agent/to-toml/default.nix
@@ -1,0 +1,48 @@
+{ lib }:
+let
+  inherit (lib)
+    concatStrings
+    mapAttrsToList
+    ;
+  inherit (builtins)
+    abort
+    match
+    toJSON
+    typeOf
+    ;
+
+  quoteKey = k:
+    if match "[a-zA-Z]+" k == []
+    then k
+    else quoteString k;
+
+  quoteString = builtins.toJSON;
+
+in
+{
+  toTOML = attrs:
+    if typeOf attrs != "set"
+    then abort "toTOML needs an attribute set"
+    else let
+      sectionContents = p: attrs:
+        concatStrings (
+          mapAttrsToList (
+            k: v:
+              if typeOf v == "string" 
+              then "${quoteKey k} = ${quoteString v}\n"
+              else if typeOf v == "bool" 
+              then "${quoteKey k} = ${toJSON v}\n"
+              else if typeOf v == "int"
+              then "${quoteKey k} = ${toJSON v}\n"
+              else if typeOf v == "float"
+              then abort "toTOML: ${k}: float not implemented yet"
+              else if typeOf v == "list"
+              then abort "toTOML: ${k}: list not implemented yet"
+              else if typeOf v == "set"
+              then abort "toTOML: ${k}: nested set / tables not implemented yet"
+              else abort "toTOML: ${k}: type ${typeOf v} not supported"
+          ) attrs
+        );
+    in
+      sectionContents [] attrs;
+}

--- a/modules/services/hercules-ci-agent/to-toml/test-run.nix
+++ b/modules/services/hercules-ci-agent/to-toml/test-run.nix
@@ -1,0 +1,21 @@
+{ lib, runCommand, path, nix, ... }:
+
+# To iterate:
+# nix-instantiate --json --strict --readonly-mode --eval --expr 'with import <nixpkgs> {}; import ./to-toml.test.nix { src = ./to-toml.nix; inherit lib; }'
+
+runCommand "to-toml-test-run" {
+  NIX_PATH = "nixpkgs=${path}";
+  nativeBuildInputs = [ nix ];
+} ''
+  export NIX_LOG_DIR=$PWD
+  export NIX_STATE_DIR=$PWD
+  nix-instantiate \
+    --eval \
+    --strict \
+    --json \
+    --option sandbox false \
+    --readonly-mode \
+    --expr "with (import <nixpkgs> {}); import ${./tests.nix} { src = ${./default.nix}; inherit lib; }" \
+    > $out
+  diff <(echo -n '{"failures":{}}') $out
+''

--- a/modules/services/hercules-ci-agent/to-toml/tests.nix
+++ b/modules/services/hercules-ci-agent/to-toml/tests.nix
@@ -1,0 +1,83 @@
+{ lib, src }:
+let
+
+  inherit (import src {inherit lib;}) toTOML;
+
+  testCase =
+    name: {input, expected}:
+      let actual = toTOML input;
+      in
+      if builtins.fromTOML expected != input
+      then builtins.abort "Error in test suite or fromTOML in case ${name}: ${builtins.toJSON (builtins.fromTOML expected)}"
+      else
+        if actual == expected
+        then null
+        else { inherit input expected actual; };
+
+  run = tcs: { failures = lib.filterAttrs (k: v: v != null) (lib.mapAttrs testCase tcs); };
+
+in run {
+  empty.input = {};
+  empty.expected = "";
+
+  keyStringValue.input = { hello = "world"; };
+  keyStringValue.expected =
+  ''hello = "world"
+  '';
+
+  keyBoolValue.input = { a = true; b = false; };
+  keyBoolValue.expected = ''
+    a = true
+    b = false
+  '';
+
+  keyIntValue.input = { a = 0; b = 10000; c = -4; };
+  keyIntValue.expected = ''
+    a = 0
+    b = 10000
+    c = -4
+  '';
+
+  /*
+
+  Maybe it's best to go with the inline syntax?
+
+  tablesAndArrays.input = {
+    fruit = [
+      {
+        name = "apple";
+        physical = {
+          color = "red";
+          shape = "round";
+        };
+        variety = [
+          { name = "red delicious"; }
+          { name = "granny smith"; }
+        ];
+      }
+      {
+        name = "banana";
+        variety = [
+          { name = "plantain"; }
+        ];
+      }
+    ];
+  };
+  tablesAndArrays.expected = ''
+    [[fruit]]
+    name = "apple"
+      [fruit.physical]
+        color = "red"
+        shape = "round"
+      [[fruit.variety]]
+        name = "red delicious"
+      [[fruit.variety]]
+        name = "granny smith"
+    [[fruit]]
+      name = "banana"
+      [[fruit.variety]]
+        name = "plantain"
+  '';
+
+  */
+}

--- a/modules/system/etc.nix
+++ b/modules/system/etc.nix
@@ -48,14 +48,20 @@ in
 
       for f in $(find /etc/static/* -type l); do
         l=/etc/''${f#/etc/static/}
+        lbackup="$l.nix-darwin.bkp"
         d=''${l%/*}
         if [ ! -e "$d" ]; then
           mkdir -p "$d"
         fi
+        if [ -e "$lbackup" ]; then
+          echo "[1;31mwarning: Backup $lbackup still exists. Review/diff if it's still needed, make a backup and remove it.[0m" >&2
+        fi
         if [ -e "$l" ]; then
           if [ "$(readlink $l)" != "$f" ]; then
             if ! grep -q /etc/static "$l"; then
-              echo "[1;31mwarning: not linking environment.etc.\"''${l#/etc/}\" because $l exists, skipping...[0m" >&2
+              echo "[1;31mwarning: Backing up $l to $lbackup and replacing the original file with linking \"''${l#/etc/}\".[0m" >&2
+              mv "$l" "$lbackup"
+              ln -s "$f" "$l"
             fi
           fi
         else


### PR DESCRIPTION
# TODO

- [x] [rm /etc/nix/nix.conf](https://github.com/LnL7/nix-darwin/issues/149)
- [x] `binaryCachesPath` / `binaryCachesPathDeployed` naming
- [x] wait on agent release
- [ ] upstream to nix-darwin
